### PR TITLE
fix: 삭제된 사진이 앨범 썸네일에 노출되는 문제 해결

### DIFF
--- a/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
+++ b/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
@@ -11,13 +11,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
-    // 특정 앨범 ID에 속한 모든 사진 조회
+    // 삭제되지 않은 특정 앨범의 모든 사진 목록 조회
     @Query(value = "SELECT * FROM photo WHERE album_id = :albumId AND is_deleted = false", nativeQuery = true)
     List<Photo> findByAlbumIdAndNotDeleted(@Param("albumId") Long albumId);
 
-    // 특정 앨범에서 가장 최신 사진 1개 조회
-    @Query("SELECT p FROM Photo p WHERE p.album.id = :albumId ORDER BY p.photoDatetime DESC LIMIT 1")
+    // 삭제되지 않은 특정 앨범의 최신 사진 1개 조회 (캡처 시간 기준 내림차순)
+    @Query("SELECT p FROM Photo p WHERE p.album.id = :albumId AND p.isDeleted = false ORDER BY p.photoDatetime DESC")
     Optional<Photo> findLatestPhotoByAlbumId(@Param("albumId") Long albumId);
+
 
     // 전체 키워드 검색
     @Query("SELECT DISTINCT p FROM Photo p " +


### PR DESCRIPTION
## 작업 내용  
- 썸네일 조회 쿼리에 `is_deleted = false` 조건 추가  
- 삭제된 사진이 썸네일에 포함되는 문제 수정  
- 관련 테스트 케이스 검증 및 추가 예정 (필요 시)

## 문제점  
- 기존 코드 수정 후 삭제된 사진이 썸네일에 노출되는 회귀 버그 발생

## 영향 범위  
- 앨범 썸네일 UI에서 부적절한 사진 노출 문제 해결  
- 사용자 경험 개선

## 참고 사항  
- 복원 및 삭제 상태 반영 로직 전반 검토 권장  
