### PR TITLE
fix: 앨범 최신 사진 조회 시 다중 결과 예외 방지 및 성능 개선

### DIFF
--- a/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
+++ b/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
@@ -1,14 +1,13 @@
 package side.project.collec.photo.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import side.project.collec.photo.domain.Photo;
-import side.project.collec.user.domain.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
     // 삭제되지 않은 특정 앨범의 모든 사진 목록 조회
@@ -17,7 +16,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     // 삭제되지 않은 특정 앨범의 최신 사진 1개 조회 (캡처 시간 기준 내림차순)
     @Query("SELECT p FROM Photo p WHERE p.album.id = :albumId AND p.isDeleted = false ORDER BY p.photoDatetime DESC")
-    Optional<Photo> findLatestPhotoByAlbumId(@Param("albumId") Long albumId);
+    List<Photo> findLatestPhotoByAlbumId(@Param("albumId") Long albumId, Pageable pageable);
 
 
     // 전체 키워드 검색

--- a/src/main/java/side/project/collec/userAlbum/service/UserAlbumService.java
+++ b/src/main/java/side/project/collec/userAlbum/service/UserAlbumService.java
@@ -3,6 +3,7 @@ package side.project.collec.userAlbum.service;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +14,7 @@ import side.project.collec.photo.repository.PhotoRepository;
 import side.project.collec.userAlbum.domain.UserAlbum;
 import side.project.collec.userAlbum.repository.UserAlbumRepository;
 
+import java.awt.print.Pageable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,7 +42,8 @@ public class UserAlbumService {
         return userAlbum.getAlbums().stream()
                 .map(album -> {
                     // 최신 사진
-                    Photo latestPhoto = photoRepository.findLatestPhotoByAlbumId(album.getId()).orElse(null);
+                    List<Photo> photos = photoRepository.findLatestPhotoByAlbumId(album.getId(), PageRequest.of(0, 1));
+                    Photo latestPhoto = photos.isEmpty() ? null : photos.get(0);
                     // 사진 개수
                     int photoCount = photoRepository.countByAlbumIdAndNotDeleted(album.getId());
                     return new AlbumResponseDto(album, latestPhoto, photoCount);


### PR DESCRIPTION
## 작업 내용
- `findLatestPhotoByAlbumId` 쿼리에 `Pageable` 파라미터 추가하여 최신 1장만 조회되도록 수정
- 서비스단에서 `PageRequest.of(0, 1)`로 필요한 사진 1장만 조회하도록 변경
- `getSingleResult()` 호출 시 발생하던 `IncorrectResultSizeDataAccessException` 문제 해결
- 불필요한 전체 사진 조회 제거로 성능 최적화

## 문제점
- 기존 로직은 단일 결과를 기대하면서도 복수 결과가 반환될 수 있어 런타임 예외가 발생함
- 최신 1장만 필요함에도 불구하고 전체 사진을 조회하여 성능 비효율 발생

## 영향 범위
- 앨범 목록에서 썸네일(최신 사진) 조회 로직 안정성 및 성능 개선
- 예외 방지로 인해 서비스 안정성 향상

## 참고 사항
- 추후 최신 사진 외에도 다건 조회가 필요한 경우 `Pageable` 재활용 가능
- 해당 변경 사항에 대한 테스트 커버리지는 이후 테스트 코드 보강 예정
