### PR TITLE
fix: 앨범 사진 조회 시 정렬 기준 설정

### DIFF
--- a/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
+++ b/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
     // 삭제되지 않은 특정 앨범의 모든 사진 목록 조회
-    @Query(value = "SELECT * FROM photo WHERE album_id = :albumId AND is_deleted = false", nativeQuery = true)
+    @Query(value = "SELECT * FROM photo WHERE album_id = :albumId AND is_deleted = false ORDER BY photo_datetime DESC", nativeQuery = true)
     List<Photo> findByAlbumIdAndNotDeleted(@Param("albumId") Long albumId);
 
     // 삭제되지 않은 특정 앨범의 최신 사진 1개 조회 (캡처 시간 기준 내림차순)


### PR DESCRIPTION
## 작업 내용
- 앨범 썸네일 조회용 native 쿼리에 `is_deleted = false` 조건 추가
- `photo_datetime` 기준 내림차순 정렬로 최신 사진 우선 조회
- 삭제된 사진이 노출되는 문제 방지

## 문제점
- 기존 native 쿼리에 삭제 여부 조건이 누락되어 삭제된 사진도 썸네일 후보로 조회됨
- 앨범 썸네일에 부적절한 사진이 노출되는 회귀 버그 발생

## 영향 범위
- 홈 화면 및 앨범 리스트 썸네일 UI
- 사용자에게 보여지는 대표 사진의 정확도 향상
- 삭제된 콘텐츠의 잘못된 노출 방지

## 참고 사항
- 복원/삭제 처리와 관련된 쿼리 전반에 대해 일관된 조건 적용 필요
- 유사 로직들에 대해서도 점검 및 통일화 권장