### PR TITLE
fix: 서버 기본 시간대를 Asia/Seoul로 설정하여 시간대 불일치 문제 해결

### DIFF
--- a/src/main/java/side/project/collec/CollecApplication.java
+++ b/src/main/java/side/project/collec/CollecApplication.java
@@ -1,13 +1,24 @@
 package side.project.collec;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.util.TimeZone;
+
 
 @SpringBootApplication
 @EnableScheduling
+@OpenAPIDefinition(servers = {@Server(url = "https://collec.site", description = "콜렉 사이트")})
 public class CollecApplication {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(CollecApplication.class, args);


### PR DESCRIPTION
## 작업 내용
- **Java 애플리케이션 시작 시** 시스템 타임존을 Asia/Seoul로 설정하는 코드 추가
- DB에 저장되거나 클라이언트에 반환되는 시간 값의 UTC-KST 불일치 문제 해결
- `spring.jackson.time-zone` 설정 추가

## 문제점
- 서버 기본 시간대가 UTC로 되어 있어, 저장 및 응답 시간값이 한국 시간과 달라지는 문제 발생
- 운영 환경과 개발 환경 간 시간대 차이로 인한 데이터 혼란 가능성

## 영향 범위
- DB에 저장되는 모든 시간 데이터
- 클라이언트에 반환되는 API 응답 내 시간 필드
- 시간대를 기준으로 하는 로직 및 테스트

## 참고 사항
- 서버 OS 타임존도 Asia/Seoul로 맞추었음
- 추가 테스트 필요 및 환경별 시간대 설정 점검 필요