### PR TITLE
fix: OCR 결과 텍스트 길이 조절

### DIFF
--- a/src/main/java/side/project/collec/photo/domain/Photo.java
+++ b/src/main/java/side/project/collec/photo/domain/Photo.java
@@ -30,7 +30,7 @@ public class Photo {
     @Column(name = "photo_datetime", nullable = false)
     private LocalDateTime photoDatetime;
 
-    @Column(name = "caption", length = 1000)
+    @Column(name = "caption", length = 3000)
     private String caption;
 
     @Column(name = "category")


### PR DESCRIPTION
## 작업 내용
- OCR 결과 텍스트가 1000자를 초과할 때 발생하는 SQL too long 예외 수정
- DB 컬럼(`caption`)의 길이 제한을 `VARCHAR(1000)`에서 `VARCHAR(3000)` 으로 변경
- 긴 텍스트 저장 시 오류 방지 및 안정성 확보

## 문제점
- OCR로 추출된 텍스트가 1000자를 초과할 경우 DB 저장 시 예외 발생
- 기존 컬럼 길이 제한으로 인해 데이터 손실 또는 서비스 장애 우려

## 영향 범위
- OCR 결과 저장 로직 및 관련 DB 테이블 스키마
- 텍스트 기반 검색 및 조회 기능에 간접 영향 가능

## 참고 사항
- 변경 후 관련 테스트 케이스 검증 필요
