### PR TITLE
refactor: CORS 설정 개선, Album 엔티티 및 리포지토리 정리 작업

### DIFF
--- a/src/main/java/side/project/collec/album/domain/Album.java
+++ b/src/main/java/side/project/collec/album/domain/Album.java
@@ -18,6 +18,7 @@ public class Album {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "album_name", nullable = false)
     private String albumName;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/side/project/collec/album/repository/AlbumRepository.java
+++ b/src/main/java/side/project/collec/album/repository/AlbumRepository.java
@@ -12,13 +12,5 @@ import java.util.Optional;
 public interface AlbumRepository extends JpaRepository<Album, Long> {
     Optional<Album> findById(Long albumId);
 
-    @Query(value = """
-    SELECT * FROM album
-    WHERE device_uid = :deviceUID
-    ORDER BY user_album_id ASC, id ASC
-    LIMIT 1
-    """, nativeQuery = true)
-    Optional<Album> findFirstAlbumByDeviceUID(@Param("deviceUID") String deviceUID);
-
     Optional<Album> findByAlbumNameAndUserAlbum(String albumName, UserAlbum userAlbum);
 }

--- a/src/main/java/side/project/collec/global/config/WebConfig.java
+++ b/src/main/java/side/project/collec/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
+        registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "https://collec.site")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")


### PR DESCRIPTION
## 작업 내용
- CORS 설정 개선
  - `/api/**`와 모든 경로(`/`)에 대해 CORS 매핑 추가
  - 허용 도메인에 `http://localhost:3000`과 `https://collec.site` 명시
  - 허용 HTTP 메서드(GET, POST, PUT, DELETE) 및 모든 헤더 허용 설정

- Album 엔티티 수정
  - `album_name` 컬럼 추가 및 NOT NULL 제약 조건 설정

- AlbumRepository 리팩토링
  - 사용하지 않는 메서드 삭제
    - `findById(Long albumId)`
    - `findFirstAlbumByDeviceUID(String deviceUID)`
    - `findByAlbumNameAndUserAlbum(String albumName, UserAlbum userAlbum)`
  - 코드 간결화 및 유지보수성 향상

## 문제점
- 기존 CORS 설정이 제한적이라 클라이언트 요청 차단 가능성 존재
- Album 엔티티에 앨범명 저장 필드가 없어 기능 제약
- AlbumRepository에 불필요한 메서드가 존재해 코드 복잡도 증가

## 영향 범위
- 프론트엔드와 백엔드 API 통신 전반
- 앨범 생성 및 조회 기능
- 데이터 접근 로직 전반

## 참고 사항
- DB 스키마 변경에 따른 마이그레이션 필요
- 삭제된 리포지토리 메서드 호출 여부 확인 완료
- 필요 시 추가 CORS 설정 확장 가능
