### PR TITLE
fix: 휴지통 조회 시 삭제된 순서대로 정렬

### DIFF
--- a/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
+++ b/src/main/java/side/project/collec/photo/repository/PhotoRepository.java
@@ -45,7 +45,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     int countByAlbumIdAndNotDeleted(@Param("albumId") Long albumId);
 
 
-    @Query("SELECT p FROM Photo p WHERE p.album.userAlbum.user.deviceUID = :deviceUID AND p.isDeleted = true")
+    @Query("SELECT p FROM Photo p WHERE p.album.userAlbum.user.deviceUID = :deviceUID AND p.isDeleted = true ORDER BY p.deletedAt DESC")
     List<Photo> findAllDeletedByDeviceUID(@Param("deviceUID") String deviceUID);
 
     List<Photo> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime threshold);


### PR DESCRIPTION
## ✏️ Description

휴지통에서 삭제된 사진들을 조회할 때, 삭제된 순서(삭제 시각) 기준으로 **최신순 정렬**되도록 쿼리를 수정하였습니다.
기존에는 `isDeleted`만 기준으로 정렬되어 의미 없는 정렬이 되었던 문제를 해결하였습니다.

## 🔧 변경 사항

* `PhotoRepository`의 `findAllDeletedByDeviceUID` 메서드 수정
* 정렬 기준을 `isDeleted` → `deletedAt` 필드 기준으로 변경
* 삭제된 시간(`deletedAt`)이 가장 최근인 사진이 가장 위에 오도록 `ORDER BY deletedAt DESC` 적용

```java
@Query("SELECT p FROM Photo p WHERE p.album.userAlbum.user.deviceUID = :deviceUID AND p.isDeleted = true ORDER BY p.deletedAt DESC")
List<Photo> findAllDeletedByDeviceUID(@Param("deviceUID") String deviceUID);
```

## ✅ 기대 효과

* 사용자가 휴지통에서 **가장 최근에 삭제한 사진**을 우선적으로 확인 가능
* 복구 및 완전 삭제 기능 시 UX 향상
* 삭제된 데이터의 시간 기반 정렬이 가능해져 유지보수성 증가